### PR TITLE
fix:  [Errno 2] No such file or directory: b'/bin/alembic'

### DIFF
--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -6,3 +6,4 @@ ENV PYTHONDONTWRITEBYTECODE 1
 WORKDIR /src
 
 RUN pip install poetry
+RUN poetry config virtualenvs.in-project true


### PR DESCRIPTION
# Overview <!-- What is the change -->
```sh
>  docker-compose run fastapi poetry run alembic upgrade head
Starting barifac_postgres_1 ... done
Creating virtualenv api-VsnhxLU2-py3.8 in /root/.cache/pypoetry/virtualenvs

  FileNotFoundError

  [Errno 2] No such file or directory: b'/bin/alembic'

  at /usr/local/lib/python3.8/os.py:601 in _execvpe
       597│         path_list = map(fsencode, path_list)
       598│     for dir in path_list:
       599│         fullname = path.join(dir, file)
       600│         try:
    →  601│             exec_func(fullname, *argrest)
       602│         except (FileNotFoundError, NotADirectoryError) as e:
       603│             last_exc = e
       604│         except OSError as e:
       605│             last_exc = e

```

poetryの環境をプロジェクト内に作成する設定になっていないため、poetry installしてもそのライブラリが見つからない状況となっていた


# Issue number <!-- e.g. Close #123, Fix #456 -->
Close #


# How to check the revision
1. build --no-cacheしてから検証

# Points for Review <!-- Things you want reviewers to check, etc. -->


# Remarks <!-- Any other comments -->


<!-- You don't have to fill in all the blanks, but write the necessary information clearly. -->